### PR TITLE
fix: Add complete player stats to API serializer and clean up views

### DIFF
--- a/backend/roster/serializer.py
+++ b/backend/roster/serializer.py
@@ -28,7 +28,27 @@ class PlayerSerializer(PlayerNameValidationMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Player
-        fields = ["id", "name", "team", "team_name", "position", "xwoba", "bb_percent", "k_percent", "barrel_batted_rate"]
+        fields = [
+            "id",
+            "name",
+            "team",
+            "team_name",
+            "position",
+            "woba",
+            "xwoba",
+            "bb_percent",
+            "k_percent",
+            "barrel_batted_rate",
+            "on_base_percent",
+            "slg_percent",
+            "sprint_speed",
+            "r_total_stolen_base",
+            "isolated_power",
+            "hard_hit_percent",
+            "home_run",
+            "pa",
+            "year",
+        ]
 
 
 class PlayerListSerializer(serializers.ModelSerializer):

--- a/backend/roster/urls.py
+++ b/backend/roster/urls.py
@@ -22,5 +22,4 @@ router.register(r"players", views.PlayerViewSet, basename="player")
 
 urlpatterns = [
     path("", include(router.urls)),
-    path("players/ranked/", views.players_ranked, name="player-ranked"),
 ]

--- a/backend/roster/views.py
+++ b/backend/roster/views.py
@@ -1,34 +1,7 @@
-import json
-
-from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods
 from rest_framework import viewsets
 
 from .models import Player, Team
 from .serializer import PlayerSerializer, TeamSerializer
-
-
-@csrf_exempt
-@require_http_methods(["GET", "POST"])
-def players(request):
-    """API endpoint to list and create players."""
-    if request.method == "GET":
-        # List all players with stats
-        players = Player.objects.all().values(
-            "id",
-            "name",
-            "xwoba",
-            "bb_percent",
-            "k_percent",
-            "barrel_batted_rate",
-            "pa",
-            "year",
-            "created_at",
-            "updated_at",
-        )
-        player_data = list(players)
-        return JsonResponse({"players": player_data})
 
 
 class TeamViewSet(viewsets.ModelViewSet):
@@ -49,56 +22,3 @@ class PlayerViewSet(viewsets.ModelViewSet):
 
     queryset = Player.objects.all()
     serializer_class = PlayerSerializer
-
-
-@csrf_exempt
-@require_http_methods(["DELETE"])
-def player_detail(request, player_id):
-    """API endpoint to delete a specific player."""
-    try:
-        player = Player.objects.get(id=player_id)
-        player_name = player.name
-        player.delete()
-        return JsonResponse({"message": f"Player '{player_name}' deleted successfully"})
-    except Player.DoesNotExist:
-        return JsonResponse({"error": "Player not found"}, status=404)
-    except Exception as e:
-        return JsonResponse({"error": str(e)}, status=400)
-
-
-@csrf_exempt
-@require_http_methods(["GET"])
-def players_ranked(request):
-    """API endpoint to get players ranked by WOS score."""
-    try:
-        # Fetch all players with stats
-        players = Player.objects.all().values(
-            "id",
-            "name",
-            "xwoba",
-            "bb_percent",
-            "k_percent",
-            "barrel_batted_rate",
-            "pa",
-            "year",
-        )
-        players_list = list(players)
-
-        """
-        Sort by WOS
-        sorted_players = sort_players_by_wos(players_list, ascending=False)
-
-        # Add WOS score to each player
-        """
-        """
-        for player in sorted_players:
-            player_data = dict(player)
-            player_data["wos_score"] = round(calculate_wos(player), 2)
-            result.append(player_data)
-        """
-        result = []
-
-        return JsonResponse({"players": result})
-
-    except Exception as e:
-        return JsonResponse({"error": str(e)}, status=500)


### PR DESCRIPTION
- Updated PlayerSerializer to include all required fields for lineup optimization
  * Added: woba, on_base_percent, slg_percent, sprint_speed, r_total_stolen_base
  * Added: isolated_power, hard_hit_percent, home_run, pa, year
- Removed dead code from views.py
  * Removed unused players() function-based view
  * Removed unused player_detail() function
  * Removed players_ranked() stub that returned empty results
  * Removed unused imports (json, JsonResponse, csrf_exempt, require_http_methods)
- Cleaned up urls.py by removing unused players/ranked/ endpoint
- PlayerViewSet now properly serves complete player data via REST framework